### PR TITLE
Add a function to check current language

### DIFF
--- a/src/translater.js
+++ b/src/translater.js
@@ -39,6 +39,9 @@ Translater.prototype = {
             }
         }
         setCookie('t-lang',name,24);
+    },
+    getLang:function() {
+	return this.lang_name;
     }
 }
 


### PR DESCRIPTION
Added a function getLang so that I can set the language initially if default is set, but it reads it from the cookie when returning to the page.

```
    <script type="text/javascript">
        var tran = new Translater();
        if (tran.getLang() === "default") tran.setLang('en');
    </script>
```
